### PR TITLE
AsyncEventHandler expects disconnect method.

### DIFF
--- a/wyoming_snd_external/__main__.py
+++ b/wyoming_snd_external/__main__.py
@@ -127,7 +127,7 @@ class ExternalEventHandler(AsyncEventHandler):
         finally:
             self._proc = None
 
-    async def disconnected(self) -> None:
+    async def disconnect(self) -> None:
         await self._stop_proc()
 
 

--- a/wyoming_snd_external/__main__.py
+++ b/wyoming_snd_external/__main__.py
@@ -123,7 +123,8 @@ class ExternalEventHandler(AsyncEventHandler):
             return
 
         try:
-            self._proc.terminate()
+            self._proc.stdin.write_eof()
+            await self._proc.stdin.wait_closed()
         finally:
             self._proc = None
 


### PR DESCRIPTION
Wyoming's `AsyncEventHandler` base class defines `disconnect` not `disconnected` method: https://github.com/rhasspy/wyoming/blob/master/wyoming/server.py#L40

With this fixed, `self._stop_proc` is now called when the client disconnects, preventing stale `command` processes.

EDIT: It looks like this fix can cause the command to be terminated while still playing audio. I'm not sure of any way to 'know' that the command is safe to be terminated. The only approach I can think of is to refactor this module to match wyoming-mic-external and run a single long-running 'global' command at start.

